### PR TITLE
Allow alarms when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improved monthly and yearly repeat intervals to perform accurately. Monthly interval will always
   trigger the same day each month, while yearly intervals will always trigger the same month and
   day each year.
+* Allow setting alarms that will trigger even when Android 6.0 (API level 23) enters doze mode.
 
 Version 1.3.0
 * Fix custom sounds to prevent them triggering when notifications are disabled

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ the ANE to work:
             android:authorities="<package_name>.notification_sound_provider"
             android:enabled="true"
             android:exported="true"/>
-
         </application>
       </manifest>
       ]]>

--- a/src/AS/src/com/juankpro/ane/localnotif/Notification.as
+++ b/src/AS/src/com/juankpro/ane/localnotif/Notification.as
@@ -166,11 +166,29 @@
      * Determines whether the notification triggers at the exact time or not.
      * If <code>isExact</code> is false then the notification will be batched with other alarms
      * to minimize battery use, otherwise the notification will trigger at the exact time.
-     * <p>Notifications will always be exact prior to Android 4.4 (API level 19).</p>
+     * <p>Notifications will always be exact prior to Android 4.4 (API level 19). Exact
+     * notifications might still be affected by the Android 6.0 doze mode.</p>
      * <p>Supported OS: Android</p>
      * @default false
+     * @see #allowWhileIdle
      */
     public var isExact:Boolean = false;
+
+    /**
+     * Allows triggering the notification even when the device is in idle (a.k.a doze) mode.
+     * <p>Since Android 6.0 (API level 23), whenever a device is left idle for certain amount of time
+     * then it will enter in doze mode. In this mode, background processes are allowed to be executed
+     * only at specific operating system controlled intervals.</p>
+     * <p>If it is critical for your application to deliver notifications even after the device
+     * enters doze mode (e.g. a medical application), set this property to true. Use only when
+     * absolutely necessary.</p>
+     * <p>This property doesn't affect devices with Android systems prior to 6.0 and notifications
+     * will always trigger even while idle.</p>
+     * <p>Supported OS: Android</p>
+     * @default false
+     * @see #isExact
+     */
+    public var allowWhileIdle:Boolean = false;
 
     /**
      * The calendar interval at which to reschedule the notification.

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotification.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotification.java
@@ -25,6 +25,7 @@ public class LocalNotification implements ISerializable, IDeserializable {
     public String body = "";
 
     public boolean isExact = false;
+    public boolean allowWhileIdle = false;
 
     // Sound.
     public boolean playSound = false;
@@ -63,6 +64,10 @@ public class LocalNotification implements ISerializable, IDeserializable {
                 .toMilliseconds();
     }
 
+    public boolean repeatsRecurrently() {
+        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT || isExact) && repeatInterval != 0;
+    }
+
     public LocalNotification() {
         this(null);
     }
@@ -98,6 +103,7 @@ public class LocalNotification implements ISerializable, IDeserializable {
             jsonObject.putOpt("showInForeground", showInForeground);
             jsonObject.putOpt("category", category);
             jsonObject.putOpt("isExact", isExact);
+            jsonObject.putOpt("allowWhileIdle", allowWhileIdle);
 
             for (byte anActionData : actionData) {
                 jsonObject.accumulate("actionData", (int)anActionData);
@@ -112,7 +118,7 @@ public class LocalNotification implements ISerializable, IDeserializable {
 
     public void deserialize(JSONObject jsonObject) {
         if (jsonObject != null) {
-            this.code = jsonObject.optString("code", code);
+            code = jsonObject.optString("code", code);
             tickerText = jsonObject.optString("tickerText", tickerText);
             title = jsonObject.optString("title", title);
             body = jsonObject.optString("body", body);
@@ -130,6 +136,7 @@ public class LocalNotification implements ISerializable, IDeserializable {
             showInForeground = jsonObject.optBoolean("showInForeground", showInForeground);
             category = jsonObject.optString("category", category);
             isExact = jsonObject.optBoolean("isExact", isExact);
+            allowWhileIdle = jsonObject.optBoolean("allowWhileIdle", allowWhileIdle);
 
             long dateTime = jsonObject.optLong("fireDate", fireDate.getTime());
 

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotificationManager.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotificationManager.java
@@ -5,7 +5,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 
 import com.juankpro.ane.localnotif.factory.NotificationRequestIntentFactory;
 import com.juankpro.ane.localnotif.factory.NotificationStrategyFactory;

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotificationManager.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/LocalNotificationManager.java
@@ -8,6 +8,8 @@ import android.content.Intent;
 import android.os.Build;
 
 import com.juankpro.ane.localnotif.factory.NotificationRequestIntentFactory;
+import com.juankpro.ane.localnotif.factory.NotificationStrategyFactory;
+import com.juankpro.ane.localnotif.notifier.INotificationStrategy;
 import com.juankpro.ane.localnotif.util.Logger;
 import com.juankpro.ane.localnotif.util.NextNotificationCalculator;
 import com.juankpro.ane.localnotif.util.PersistenceManager;
@@ -22,52 +24,32 @@ class LocalNotificationManager {
     private Context context;
     private NotificationManager notificationManager;
     private NotificationRequestIntentFactory intentFactory;
+    private INotificationStrategy notifier;
 
     LocalNotificationManager(Context context) {
         this.context = context;
         intentFactory = new NotificationRequestIntentFactory(context);
         notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notifier = new NotificationStrategyFactory(context).create();
     }
 
-    void notify(LocalNotification localNotification) {
-        NextNotificationCalculator calculator = new NextNotificationCalculator(localNotification);
+    void notify(LocalNotification notification) {
+        NextNotificationCalculator calculator = new NextNotificationCalculator(notification);
         long notificationTime = calculator.getTime(new Date());
 
         PendingIntent pendingIntent = PendingIntent.getBroadcast(
                 context,
-                localNotification.code.hashCode(),
-                intentFactory.createIntent(localNotification),
+                notification.code.hashCode(),
+                intentFactory.createIntent(notification),
                 PendingIntent.FLAG_CANCEL_CURRENT);
-        long repeatInterval = localNotification.getRepeatIntervalMilliseconds();
+        long repeatInterval = notification.getRepeatIntervalMilliseconds();
 
         if (repeatInterval != 0) {
-            setRepeatingAlarm(notificationTime, repeatInterval, pendingIntent, localNotification.isExact);
+            notifier.notifyRepeating(notificationTime, repeatInterval, pendingIntent, notification);
         }
         else {
-            setAlarm(notificationTime, pendingIntent, localNotification.isExact);
+            notifier.notify(notificationTime, pendingIntent, notification);
         }
-    }
-
-    private void setRepeatingAlarm(long notificationTime, long repeatInterval, PendingIntent pendingIntent, boolean isExact) {
-        AlarmManager am = getAlarmManager();
-
-        if (isExact) {
-            setAlarm(notificationTime, pendingIntent, true);
-        }
-        else {
-            am.setInexactRepeating(AlarmManager.RTC_WAKEUP, notificationTime, repeatInterval, pendingIntent);
-        }
-    }
-
-    private void setAlarm(long notificationTime, PendingIntent pendingIntent, boolean isExact) {
-        AlarmManager am = getAlarmManager();
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT || !isExact) {
-            am.set(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
-            return;
-        }
-
-        am.setExact(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
     }
 
     void cancel(String notificationCode) {

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/decoder/LocalNotificationDecoder.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/decoder/LocalNotificationDecoder.java
@@ -34,6 +34,7 @@ public class LocalNotificationDecoder extends FREDecoder<LocalNotification> {
         localNotification.fireDate = decodeDate("fireDate", localNotification.fireDate);
         localNotification.repeatInterval = decodeInt("repeatInterval", localNotification.repeatInterval);
         localNotification.isExact = decodeBoolean("isExact", localNotification.isExact);
+        localNotification.allowWhileIdle = decodeBoolean("allowWhileIdle", localNotification.allowWhileIdle);
 
         // Text.
         localNotification.tickerText = decodeString("tickerText", localNotification.tickerText);

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/factory/NotificationRequestIntentFactory.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/factory/NotificationRequestIntentFactory.java
@@ -40,7 +40,7 @@ public class NotificationRequestIntentFactory {
         intent.putExtra(Constants.SHOW_IN_FOREGROUND, localNotification.showInForeground);
         intent.putExtra(Constants.CATEGORY, localNotification.category);
 
-        if (localNotification.isExact && localNotification.repeatInterval != 0) {
+        if (localNotification.repeatsRecurrently()) {
             intent.putExtra(Constants.REPEAT_INTERVAL, localNotification.repeatInterval);
         }
 
@@ -50,5 +50,4 @@ public class NotificationRequestIntentFactory {
 
         return intent;
     }
-
 }

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/factory/NotificationStrategyFactory.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/factory/NotificationStrategyFactory.java
@@ -1,0 +1,28 @@
+package com.juankpro.ane.localnotif.factory;
+
+import android.content.Context;
+import android.os.Build;
+
+import com.juankpro.ane.localnotif.notifier.INotificationStrategy;
+import com.juankpro.ane.localnotif.notifier.KitKatNotifier;
+import com.juankpro.ane.localnotif.notifier.LegacyNotifier;
+import com.juankpro.ane.localnotif.notifier.MarshmallowNotifier;
+
+public class NotificationStrategyFactory {
+
+    private Context context;
+
+    public NotificationStrategyFactory(Context context) {
+        this.context = context;
+    }
+
+    public INotificationStrategy create() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+            return new LegacyNotifier(context);
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return new KitKatNotifier(context);
+        }
+        return new MarshmallowNotifier(context);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/BaseNotifier.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/BaseNotifier.java
@@ -1,0 +1,35 @@
+package com.juankpro.ane.localnotif.notifier;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+
+import com.juankpro.ane.localnotif.LocalNotification;
+
+public abstract class BaseNotifier implements INotificationStrategy {
+
+    private Context context;
+
+    public BaseNotifier(Context context) {
+        this.context = context;
+    }
+
+    protected Context getContext() {
+        return context;
+    }
+
+    protected AlarmManager getAlarmManager() {
+        return (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    }
+
+    public void notifyRepeating(long notificationTime, long repeatInterval, PendingIntent pendingIntent, LocalNotification notification) {
+        AlarmManager am = getAlarmManager();
+
+        if (notification.repeatsRecurrently()) {
+            notify(notificationTime, pendingIntent, notification);
+            return;
+        }
+
+        am.setInexactRepeating(AlarmManager.RTC_WAKEUP, notificationTime, repeatInterval, pendingIntent);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/INotificationStrategy.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/INotificationStrategy.java
@@ -1,0 +1,10 @@
+package com.juankpro.ane.localnotif.notifier;
+
+import android.app.PendingIntent;
+
+import com.juankpro.ane.localnotif.LocalNotification;
+
+public interface INotificationStrategy {
+    void notify(long notificationTime, PendingIntent pendingIntent, LocalNotification localNotification);
+    void notifyRepeating(long notificationTime, long repeatInterval, PendingIntent pendingIntent, LocalNotification notification);
+}

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/KitKatNotifier.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/KitKatNotifier.java
@@ -1,0 +1,29 @@
+package com.juankpro.ane.localnotif.notifier;
+
+import android.annotation.TargetApi;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+
+import com.juankpro.ane.localnotif.LocalNotification;
+
+@TargetApi(Build.VERSION_CODES.KITKAT)
+public class KitKatNotifier extends BaseNotifier {
+
+    public KitKatNotifier(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void notify(long notificationTime, PendingIntent pendingIntent, LocalNotification localNotification) {
+        AlarmManager am = getAlarmManager();
+
+        if (localNotification.isExact) {
+            am.setExact(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
+            return;
+        }
+
+        am.set(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/LegacyNotifier.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/LegacyNotifier.java
@@ -1,0 +1,19 @@
+package com.juankpro.ane.localnotif.notifier;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+
+import com.juankpro.ane.localnotif.LocalNotification;
+
+public class LegacyNotifier extends BaseNotifier {
+
+    public LegacyNotifier(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void notify(long notificationTime, PendingIntent pendingIntent, LocalNotification localNotification) {
+        getAlarmManager().set(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/MarshmallowNotifier.java
+++ b/src/AndroidStudio/localnotif/src/main/java/com/juankpro/ane/localnotif/notifier/MarshmallowNotifier.java
@@ -1,0 +1,34 @@
+package com.juankpro.ane.localnotif.notifier;
+
+import android.annotation.TargetApi;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+
+import com.juankpro.ane.localnotif.LocalNotification;
+
+@TargetApi(Build.VERSION_CODES.M)
+public class MarshmallowNotifier extends KitKatNotifier {
+
+    public MarshmallowNotifier(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void notify(long notificationTime, PendingIntent pendingIntent, LocalNotification localNotification) {
+        if (!localNotification.allowWhileIdle) {
+            super.notify(notificationTime, pendingIntent, localNotification);
+            return;
+        }
+
+        AlarmManager am = getAlarmManager();
+
+        if (localNotification.isExact) {
+            am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
+            return;
+        }
+
+        am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, notificationTime, pendingIntent);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/KitKatNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/KitKatNotifierTest.java
@@ -1,0 +1,111 @@
+package com.juankpro.ane.localnotif;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+
+import com.juankpro.ane.localnotif.notifier.KitKatNotifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({KitKatNotifierTest.class})
+public class KitKatNotifierTest {
+    @Mock
+    private Context context;
+    @Mock
+    private PendingIntent pendingIntent;
+    @Mock
+    private AlarmManager alarmManager;
+    private KitKatNotifier subject;
+
+    private KitKatNotifier getSubject() {
+        if (subject == null) {
+            subject = spy(new KitKatNotifier(context));
+        }
+        return subject;
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(context.getSystemService(Context.ALARM_SERVICE)).thenReturn(alarmManager);
+    }
+
+    private LocalNotification getNotification() {
+        return new LocalNotification();
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = false;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).setExact(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = false;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = true;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).setExact(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = true;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+        KitKatNotifier subject = getSubject();
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(false);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(alarmManager).setInexactRepeating(AlarmManager.RTC_WAKEUP, 300, 100, pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+        KitKatNotifier subject = spy(getSubject());
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(true);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(subject).notify(300, pendingIntent, notification);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/KitKatNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/KitKatNotifierTest.java
@@ -88,7 +88,7 @@ public class KitKatNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+    public void notifier_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
         KitKatNotifier subject = getSubject();
 
         LocalNotification notification = mock(LocalNotification.class);
@@ -99,7 +99,7 @@ public class KitKatNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+    public void notifier_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
         KitKatNotifier subject = spy(getSubject());
 
         LocalNotification notification = mock(LocalNotification.class);

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LegacyNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LegacyNotifierTest.java
@@ -3,11 +3,8 @@ package com.juankpro.ane.localnotif;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.os.Build;
 
 import com.juankpro.ane.localnotif.notifier.LegacyNotifier;
-
-import net.sf.cglib.core.Local;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +13,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.Date;
 
@@ -96,7 +92,7 @@ public class LegacyNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+    public void notifier_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
         LegacyNotifier subject = getSubject();
 
         LocalNotification notification = mock(LocalNotification.class);
@@ -107,7 +103,7 @@ public class LegacyNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+    public void notifier_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
         LegacyNotifier subject = spy(getSubject());
 
         LocalNotification notification = mock(LocalNotification.class);

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LegacyNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LegacyNotifierTest.java
@@ -1,0 +1,119 @@
+package com.juankpro.ane.localnotif;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+
+import com.juankpro.ane.localnotif.notifier.LegacyNotifier;
+
+import net.sf.cglib.core.Local;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Date;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LegacyNotifier.class, LocalNotification.class})
+public class LegacyNotifierTest {
+    @Mock
+    private Context context;
+    @Mock
+    private PendingIntent pendingIntent;
+    @Mock
+    private AlarmManager alarmManager;
+    private LegacyNotifier subject;
+
+    private LegacyNotifier getSubject() {
+        if (subject == null) {
+            subject = spy(new LegacyNotifier(context));
+        }
+        return subject;
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(context.getSystemService(Context.ALARM_SERVICE)).thenReturn(alarmManager);
+    }
+
+    private LocalNotification getNotification() {
+        LocalNotification notification = new LocalNotification();
+        notification.fireDate = new Date(new Date().getTime() + 5000);
+        return notification;
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = false;
+        getSubject().notify(notification.fireDate.getTime(), pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, notification.fireDate.getTime(), pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = false;
+        getSubject().notify(notification.fireDate.getTime(), pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, notification.fireDate.getTime(), pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = true;
+        getSubject().notify(notification.fireDate.getTime(), pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, notification.fireDate.getTime(), pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = true;
+        getSubject().notify(notification.fireDate.getTime(), pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, notification.fireDate.getTime(), pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+        LegacyNotifier subject = getSubject();
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(false);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(alarmManager).setInexactRepeating(AlarmManager.RTC_WAKEUP, 300, 100, pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+        LegacyNotifier subject = spy(getSubject());
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(true);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(subject).notify(300, pendingIntent, notification);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationDecoderTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationDecoderTest.java
@@ -180,6 +180,12 @@ LocalNotificationDecoderTest {
     }
 
     @Test
+    public void decoder_decode_decodesLocalNotificationAllowWhileIdle() {
+        when(ExtensionUtils.getBooleanProperty(freArg2, "allowWhileIdle", false)).thenReturn(true);
+        assertTrue(getSubject().decodeObject(freArg2).allowWhileIdle);
+    }
+
+    @Test
     public void decoder_decode_decodesLocalNotificationPriority_zeroIfSdkLessThanNougat() {
         Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.N - 1);
         when(ExtensionUtils.getIntProperty(freArg2, "priority", 0)).thenReturn(12);

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationManagerTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationManagerTest.java
@@ -13,8 +13,6 @@ import com.juankpro.ane.localnotif.notifier.INotificationStrategy;
 import com.juankpro.ane.localnotif.util.NextNotificationCalculator;
 import com.juankpro.ane.localnotif.util.PersistenceManager;
 
-import net.sf.cglib.core.Local;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +21,6 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.Date;
 import java.util.HashSet;

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/LocalNotificationTest.java
@@ -1,5 +1,7 @@
 package com.juankpro.ane.localnotif;
 
+import android.os.Build;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,12 +13,15 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import java.util.Date;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -33,7 +38,7 @@ import static org.mockito.Mockito.when;
  */
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({LocalNotification.class})
+@PrepareForTest({LocalNotification.class, Build.VERSION.class})
 public class LocalNotificationTest {
     @Mock
     private JSONObject jsonObject;
@@ -77,7 +82,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesFromJsonObject() {
+    public void notification_deserialize_deserializesFromJsonObject() {
         when(jsonObject.optString("code", "")).thenReturn("MyCode");
         when(jsonObject.optString("tickerText", "")).thenReturn("Ticker");
         when(jsonObject.optString("title", "")).thenReturn("Title");
@@ -124,7 +129,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesPlaySoundFromJsonObject() {
+    public void notification_deserialize_deserializesPlaySoundFromJsonObject() {
         when(jsonObject.optBoolean("playSound", false)).thenReturn(true);
         assertEquals(false, getSubject().playSound);
         getSubject().deserialize(jsonObject);
@@ -132,7 +137,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesVibrateFromJsonObject() {
+    public void notification_deserialize_deserializesVibrateFromJsonObject() {
         when(jsonObject.optBoolean("vibrate", false)).thenReturn(true);
         assertEquals(false, getSubject().vibrate);
         getSubject().deserialize(jsonObject);
@@ -140,7 +145,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesCancelOnSelectFromJsonObject() {
+    public void notification_deserialize_deserializesCancelOnSelectFromJsonObject() {
         when(jsonObject.optBoolean("cancelOnSelect", false)).thenReturn(true);
         assertEquals(false, getSubject().cancelOnSelect);
         getSubject().deserialize(jsonObject);
@@ -148,7 +153,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesOngoingFromJsonObject() {
+    public void notification_deserialize_deserializesOngoingFromJsonObject() {
         when(jsonObject.optBoolean("ongoing", false)).thenReturn(true);
         assertEquals(false, getSubject().ongoing);
         getSubject().deserialize(jsonObject);
@@ -156,7 +161,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesHasActionFromJsonObject() {
+    public void notification_deserialize_deserializesHasActionFromJsonObject() {
         when(jsonObject.optBoolean("hasAction", false)).thenReturn(true);
         assertEquals(false, getSubject().hasAction);
         getSubject().deserialize(jsonObject);
@@ -164,7 +169,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesShowInForegroundFromJsonObject() {
+    public void notification_deserialize_deserializesShowInForegroundFromJsonObject() {
         when(jsonObject.optBoolean("showInForeground", false)).thenReturn(true);
         assertEquals(false, getSubject().showInForeground);
         getSubject().deserialize(jsonObject);
@@ -172,7 +177,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesByteDataFromJsonObject() {
+    public void notification_deserialize_deserializesByteDataFromJsonObject() {
         try {
             when(jsonObject.getJSONArray("actionData")).thenReturn(jsonArray);
             when(jsonArray.length()).thenReturn(2);
@@ -186,7 +191,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_deserializesIsExactFromJsonObject() {
+    public void notification_deserialize_deserializesIsExactFromJsonObject() {
         when(jsonObject.optBoolean("isExact", false)).thenReturn(true);
         assertEquals(false, getSubject().isExact);
         getSubject().deserialize(jsonObject);
@@ -194,7 +199,15 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_doesNothingIfJsonObjectIsNull() {
+    public void notification_deserialize_deserializesAllowWhileIdleFromJsonObject() {
+        when(jsonObject.optBoolean("allowWhileIdle", false)).thenReturn(true);
+        assertEquals(false, getSubject().allowWhileIdle);
+        getSubject().deserialize(jsonObject);
+        assertEquals(true, getSubject().allowWhileIdle);
+    }
+
+    @Test
+    public void notification_deserialize_doesNothingIfJsonObjectIsNull() {
         getSubject().deserialize(null);
         verify(jsonObject, never()).optString(eq("code"), anyString());
         verify(jsonObject, never()).optString(eq("tickerText"), anyString());
@@ -217,7 +230,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_deserialize_stopsDeserializingByteArrayIfAnExceptionIsThrown() {
+    public void notification_deserialize_stopsDeserializingByteArrayIfAnExceptionIsThrown() {
         try {
             when(jsonObject.getJSONArray("actionData")).thenReturn(jsonArray);
             when(jsonArray.length()).thenReturn(2);
@@ -240,7 +253,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesNotification() {
+    public void notification_serialize_serializesNotification() {
         try {
             assertSame(jsonObject, getSubject("MyCode").serialize());
             verify(jsonObject).putOpt("code", "MyCode");
@@ -260,7 +273,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesPlaySound() {
+    public void notification_serialize_serializesPlaySound() {
         try {
             getSubject().playSound = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -269,7 +282,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesVibrate() {
+    public void notification_serialize_serializesVibrate() {
         try {
             getSubject().vibrate = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -278,7 +291,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesCancelOnSelect() {
+    public void notification_serialize_serializesCancelOnSelect() {
         try {
             getSubject().cancelOnSelect = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -287,7 +300,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesOngoing() {
+    public void notification_serialize_serializesOngoing() {
         try {
             getSubject().ongoing = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -296,7 +309,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesHasAction() {
+    public void notification_serialize_serializesHasAction() {
         try {
             getSubject().hasAction = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -305,7 +318,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesShowInForeground() {
+    public void notification_serialize_serializesShowInForeground() {
         try {
             getSubject().showInForeground = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -314,7 +327,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesByteData() {
+    public void notification_serialize_serializesByteData() {
         try {
             getSubject().actionData = new byte[]{102, 127};
 
@@ -326,7 +339,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_serializesIsExact() {
+    public void notification_serialize_serializesIsExact() {
         try {
             getSubject().isExact = true;
             assertSame(jsonObject, getSubject().serialize());
@@ -335,7 +348,16 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_serialize_stopsSerializingDataIfAnExceptionIsThrown() {
+    public void notification_serialize_serializesAllowWhileIdle() {
+        try {
+            getSubject().allowWhileIdle = true;
+            assertSame(jsonObject, getSubject().serialize());
+            verify(jsonObject).putOpt("allowWhileIdle", true);
+        } catch (JSONException e) { e.printStackTrace(); }
+    }
+
+    @Test
+    public void notification_serialize_stopsSerializingDataIfAnExceptionIsThrown() {
         try {
             getSubject().actionData = new byte[]{102, 127};
             when(jsonObject.accumulate("actionData", 102)).thenThrow(mock(JSONException.class));
@@ -348,7 +370,7 @@ public class LocalNotificationTest {
     }
 
     @Test
-    public void action_getRepeatIntervalMilliseconds_returnsTimeInMilliseconds() {
+    public void notification_getRepeatIntervalMilliseconds_returnsTimeInMilliseconds() {
         LocalNotificationTimeInterval intervalMock = mock(LocalNotificationTimeInterval.class);
         try {
             PowerMockito.whenNew(LocalNotificationTimeInterval.class)
@@ -359,5 +381,37 @@ public class LocalNotificationTest {
 
         getSubject().repeatInterval = 10;
         assertEquals(getSubject().getRepeatIntervalMilliseconds(), 20000L);
+    }
+
+    @Test
+    public void notification_repeatsRecurrently_returnsTrueIfHasRepeatInterval_afterKitKat() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
+        getSubject().repeatInterval = 10;
+        getSubject().isExact = false;
+        assertTrue(getSubject().repeatsRecurrently());
+    }
+
+    @Test
+    public void notification_repeatsRecurrently_returnsTrueIfHasRepeatIntervalAndIsExact() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT - 1);
+        getSubject().repeatInterval = 10;
+        getSubject().isExact = true;
+        assertTrue(getSubject().repeatsRecurrently());
+    }
+
+    @Test
+    public void notification_repeatsRecurrently_returnsFalseIfDoesNotHaveRepeatInterval() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
+        getSubject().repeatInterval = 0;
+        getSubject().isExact = true;
+        assertFalse(getSubject().repeatsRecurrently());
+    }
+
+    @Test
+    public void notification_repeatsRecurrently_returnsFalseIfNonExact_beforeKitKat() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT - 1);
+        getSubject().repeatInterval = 10;
+        getSubject().isExact = false;
+        assertFalse(getSubject().repeatsRecurrently());
     }
 }

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/MarshmallowNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/MarshmallowNotifierTest.java
@@ -1,0 +1,111 @@
+package com.juankpro.ane.localnotif;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+
+import com.juankpro.ane.localnotif.notifier.MarshmallowNotifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MarshmallowNotifier.class})
+public class MarshmallowNotifierTest {
+    @Mock
+    private Context context;
+    @Mock
+    private PendingIntent pendingIntent;
+    @Mock
+    private AlarmManager alarmManager;
+    private MarshmallowNotifier subject;
+
+    private MarshmallowNotifier getSubject() {
+        if (subject == null) {
+            subject = spy(new MarshmallowNotifier(context));
+        }
+        return subject;
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(context.getSystemService(Context.ALARM_SERVICE)).thenReturn(alarmManager);
+    }
+
+    private LocalNotification getNotification() {
+        return new LocalNotification();
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = false;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).setExact(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andNonIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = false;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).set(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = true;
+        notification.allowWhileIdle = true;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void notifier_notify_setsAlarm_whenNonExact_andIdle() {
+        LocalNotification notification = getNotification();
+        notification.isExact = false;
+        notification.allowWhileIdle = true;
+        getSubject().notify(100, pendingIntent, notification);
+
+        verify(alarmManager).setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, 100, pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+        MarshmallowNotifier subject = getSubject();
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(false);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(alarmManager).setInexactRepeating(AlarmManager.RTC_WAKEUP, 300, 100, pendingIntent);
+    }
+
+    @Test
+    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+        MarshmallowNotifier subject = spy(getSubject());
+
+        LocalNotification notification = mock(LocalNotification.class);
+        when(notification.repeatsRecurrently()).thenReturn(true);
+        subject.notifyRepeating(300, 100, pendingIntent, notification);
+
+        verify(subject).notify(300, pendingIntent, notification);
+    }
+}

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/MarshmallowNotifierTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/MarshmallowNotifierTest.java
@@ -88,7 +88,7 @@ public class MarshmallowNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
+    public void notifier_notifyRepeating_setsRepeatingAlarm_whenNotificationDoesNotRepeatRecurrently() {
         MarshmallowNotifier subject = getSubject();
 
         LocalNotification notification = mock(LocalNotification.class);
@@ -99,7 +99,7 @@ public class MarshmallowNotifierTest {
     }
 
     @Test
-    public void manager_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
+    public void notifier_notifyRepeating_setsAlarm_whenNotificationRepeatsRecurrently() {
         MarshmallowNotifier subject = spy(getSubject());
 
         LocalNotification notification = mock(LocalNotification.class);

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/NotificationRequestIntentFactoryTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/NotificationRequestIntentFactoryTest.java
@@ -14,8 +14,12 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Created by juank on 12/18/2017.
@@ -139,12 +143,21 @@ public class NotificationRequestIntentFactoryTest {
     }
 
     @Test
-    public void factory_createIntent_addsRepeatIntervalWhenIsExactAndIntervalDefined() {
-        LocalNotification notification = getNotification();
-        notification.isExact = true;
+    public void factory_createIntent_addsRepeatInterval_whenNotificationRepeatsRecurrently() {
+        LocalNotification notification = spy(getNotification());
+        when(notification.repeatsRecurrently()).thenReturn(true);
         notification.repeatInterval = LocalNotificationTimeInterval.MINUTE_CALENDAR_UNIT;
         getSubject().createIntent(notification);
         verify(intent).putExtra(Constants.REPEAT_INTERVAL, LocalNotificationTimeInterval.MINUTE_CALENDAR_UNIT);
+    }
+
+    @Test
+    public void factory_createIntent_doesNotAddRepeatInterval_whenNotificationDoesNotRepeatRecurrently() {
+        LocalNotification notification = spy(getNotification());
+        when(notification.repeatsRecurrently()).thenReturn(false);
+        notification.repeatInterval = LocalNotificationTimeInterval.MINUTE_CALENDAR_UNIT;
+        getSubject().createIntent(notification);
+        verify(intent, never()).putExtra(eq(Constants.REPEAT_INTERVAL), anyInt());
     }
 
     @Test

--- a/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/NotificationStrategyFactoryTest.java
+++ b/src/AndroidStudio/localnotif/src/test/java/com/juankpro/ane/localnotif/NotificationStrategyFactoryTest.java
@@ -1,0 +1,62 @@
+package com.juankpro.ane.localnotif;
+
+import android.content.Context;
+import android.os.Build;
+
+import com.juankpro.ane.localnotif.factory.NotificationStrategyFactory;
+import com.juankpro.ane.localnotif.notifier.KitKatNotifier;
+import com.juankpro.ane.localnotif.notifier.LegacyNotifier;
+import com.juankpro.ane.localnotif.notifier.MarshmallowNotifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Build.VERSION.class})
+public class NotificationStrategyFactoryTest {
+    @Mock
+    private Context context;
+
+    private NotificationStrategyFactory subject;
+    private NotificationStrategyFactory getSubject() {
+        if (subject == null) { subject = new NotificationStrategyFactory(context); }
+        return subject;
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void factory_create_createsALegacyNotifier_beforeKitKat() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT - 1);
+        assertTrue(getSubject().create() instanceof LegacyNotifier);
+    }
+
+    @Test
+    public void factory_create_createsALegacyNotifier_beforeMarshmallow() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M - 1);
+        assertTrue(getSubject().create() instanceof KitKatNotifier);
+
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
+        assertTrue(getSubject().create() instanceof KitKatNotifier);
+    }
+
+    @Test
+    public void factory_create_createsALegacyNotifier_onMarshmallowAndHigher() {
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+        assertTrue(getSubject().create() instanceof KitKatNotifier);
+
+        Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.N);
+        assertTrue(getSubject().create() instanceof MarshmallowNotifier);
+    }
+}

--- a/src/AndroidStudio/testapplication/src/main/java/com/juankpro/ane/testapplication/MainActivity.java
+++ b/src/AndroidStudio/testapplication/src/main/java/com/juankpro/ane/testapplication/MainActivity.java
@@ -91,7 +91,8 @@ public class MainActivity extends Activity {
             notification.put("iconType", getFREObject("icon"));
             notification.put("numberAnnotation", getFREObject(2));
             notification.put("cancelOnSelect", getFREObject(true));
-            notification.put("isExact", getFREObject(true));
+            //notification.put("isExact", getFREObject(true));
+            //notification.put("allowWhileIdle", getFREObject(true));
             //notification.put("repeatInterval", getFREObject(LocalNotificationTimeInterval.MINUTE_CALENDAR_UNIT));
             notification.put("showInForeground", getFREObject(true));
             notification.put("actionData", getFREByteArray("Hello World!".getBytes()));


### PR DESCRIPTION
Android api level 23 created a new doze mode that prevents alarms from triggering when the phone is idle. The operating system will try to trigger notifications at specific increasingly larger intervals. This should be ok for most applications that have to take this delays into account. But if you have an application that dispatches critical notifications, now you can force them to show in doze mode too.